### PR TITLE
bug: Prevent NPE when handler can't be obtained. Fixes #14

### DIFF
--- a/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/protocol/SoulissBindingSendDispatcherJob.java
+++ b/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/protocol/SoulissBindingSendDispatcherJob.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SoulissBindingSendDispatcherJob implements Runnable {
 
-    private static Logger logger = LoggerFactory.getLogger(SoulissGatewayJobHealty.class);
+    private static Logger logger = LoggerFactory.getLogger(SoulissBindingSendDispatcherJob.class);
 
     private SoulissGatewayHandler gw;
     static boolean bPopSuspend = false;
@@ -155,12 +155,9 @@ public class SoulissBindingSendDispatcherJob implements Runnable {
 
                 resetTime();
             }
-        } catch (IOException e) {
-            logger.warn(e.getMessage());
         } catch (Exception e) {
-            logger.warn(e.getMessage());
+            logger.warn(e.getMessage(),e);
         }
-
     }
 
     /**
@@ -213,7 +210,12 @@ public class SoulissBindingSendDispatcherJob implements Runnable {
                     if (packetsList.get(i).packet.getData()[j] != 0) {
                         // recupero tipico dalla memoria
                         typ = getHandler(_iPAddressOnLAN, node, iSlot);
-                        bExpected = typ.getExpectedRawState(packetsList.get(i).packet.getData()[j]);
+
+                        if ( typ != null ) {
+                            bExpected = typ.getExpectedRawState(packetsList.get(i).packet.getData()[j]);
+                        } else {
+                            bExpected = -1;
+                        }
 
                         // se il valore atteso dal tipico è -1 allora vuol dire che il tipico non supporta la
                         // funzione


### PR DESCRIPTION
Found the problem when obtaining the handler for the second slot of a multi-slot typical.
In that case I've checked the NPE and set the expected value to -1, I think the result is the same as when entering here:
https://github.com/souliss/bindingopenhab2/blame/3abe6b19153b81d1fcc87a6de8a4901340226fc2/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/protocol/SoulissBindingSendDispatcherJob.java#L260

or here:
https://github.com/souliss/bindingopenhab2/blame/3abe6b19153b81d1fcc87a6de8a4901340226fc2/org.openhab.binding.souliss/src/main/java/org/openhab/binding/souliss/internal/protocol/SoulissBindingSendDispatcherJob.java#L264

It's working for me.

Closes #14